### PR TITLE
Add CMake package file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,37 @@ set(LXQTBT_MINIMUM_VERSION "0.12.0")
 
 find_package(lxqt-build-tools ${LXQTBT_MINIMUM_VERSION} REQUIRED)
 
+# Version
+set(LXQT_MENU_DATA_MAJOR_VERSION 1)
+set(LXQT_MENU_DATA_MINOR_VERSION 3)
+set(LXQT_MENU_DATA_PATCH_VERSION 0)
+set(LXQT_MENU_DATA_VERSION ${LXQT_MENU_DATA_MAJOR_VERSION}.${LXQT_MENU_DATA_MINOR_VERSION}.${LXQT_MENU_DATA_PATCH_VERSION})
+
 include(LXQtConfigVars)
 include(LXQtPreventInSourceBuilds)
 include(LXQtTranslate)
+
+include(CMakePackageConfigHelpers)
+
+set(LXQT_MENU_DATA_CMAKE_NAME lxqt-menu-data)
+
+configure_package_config_file(
+    "${PROJECT_SOURCE_DIR}/cmake/${LXQT_MENU_DATA_CMAKE_NAME}-config.cmake.in"
+    "${CMAKE_BINARY_DIR}/${LXQT_MENU_DATA_CMAKE_NAME}-config.cmake"
+    INSTALL_DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/${LXQT_MENU_DATA_CMAKE_NAME}"
+)
+
+write_basic_package_version_file(
+    "${CMAKE_BINARY_DIR}/${LXQT_MENU_DATA_CMAKE_NAME}-config-version.cmake"
+    VERSION ${LXQT_MENU_DATA_VERSION}
+    COMPATIBILITY AnyNewerVersion
+)
+
+install(FILES
+    "${CMAKE_BINARY_DIR}/${LXQT_MENU_DATA_CMAKE_NAME}-config.cmake"
+    "${CMAKE_BINARY_DIR}/${LXQT_MENU_DATA_CMAKE_NAME}-config-version.cmake"
+    DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/${LXQT_MENU_DATA_CMAKE_NAME}"
+    COMPONENT Devel
+)
 
 add_subdirectory(menu)

--- a/cmake/lxqt-menu-data-config.cmake.in
+++ b/cmake/lxqt-menu-data-config.cmake.in
@@ -1,0 +1,1 @@
+@PACKAGE_INIT@


### PR DESCRIPTION
Per docs [1], `ARCH_INDEPENDENT` can be added to
write_basic_package_version_file(). It needs CMake >= 3.14, and no other LXQt packages use that, so I skip it as well.

[1] https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html

---

Those changes are adapted from other LXQt projects. Some references:

https://github.com/search?q=org%3Alxqt%20configure_package_config_file&type=code

https://github.com/lxqt/lxqt-build-tools/blob/master/CMakeLists.txt
https://github.com/lxqt/libqtxdg/blob/master/CMakeLists.txt
https://github.com/lxqt/lxqt-globalkeys/blob/master/CMakeLists.txt

https://github.com/lxqt/lxqt-build-tools/blob/master/lxqt-build-tools-config.cmake.in
https://github.com/lxqt/libqtxdg/blob/master/cmake/qt5xdg-config.cmake.in
https://github.com/lxqt/lxqt-globalkeys/blob/master/cmake/lxqt_globalkeys-config.cmake.in

@tsujan the version in CMakeLists.txt should be updated during the next LXQt release.