### PR TITLE
Makes the package arch independent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
 # CMP0000: Call the cmake_minimum_required() command at the beginning of the top-level
 # CMakeLists.txt file even before calling the project() command.
 # The cmake_minimum_required(VERSION) command implicitly invokes the cmake_policy(VERSION)
@@ -36,6 +36,7 @@ write_basic_package_version_file(
     "${CMAKE_BINARY_DIR}/${LXQT_MENU_DATA_CMAKE_NAME}-config-version.cmake"
     VERSION ${LXQT_MENU_DATA_VERSION}
     COMPATIBILITY AnyNewerVersion
+    ARCH_INDEPENDENT
 )
 
 install(FILES


### PR DESCRIPTION
With ARCH_INDEPENDENT option the package is considered compatible on any architecture.
ARCH_INDEPEDENT is available on 3.14 released on March 2019. Version 3.16 was released on Nov 2019. Small difference and we will require 3.16 on the upcoming Qt6 version.

Fixes https://github.com/lxqt/lxqt-menu-data/issues/17.