### PR TITLE
Use applications-utilities icon for Utilities directory

### DIFF
--- a/menu/desktop-directories/lxqt-utility.directory.in
+++ b/menu/desktop-directories/lxqt-utility.directory.in
@@ -191,5 +191,5 @@ Comment[xh]=Izinto ezongezelelwayo ze-Desktop
 Comment[zh_CN]=桌面附件
 Comment[zh_HK]=桌面附屬應用程式
 Comment[zh_TW]=桌面附屬應用程式
-Icon=applications-accessories
+Icon=applications-utilities
 Type=Directory


### PR DESCRIPTION
The `applications-accessories` icon is missing from the Breeze icon theme, which is [used in LXQt by default](https://github.com/lxqt/lxqt-session/commit/5d32ff434d47f6daee3dccd1835083840f6a299e).